### PR TITLE
Disable nested ternary rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = {
         "maxEOF": 0
       }
     ],
+    "no-nested-ternary": "off",
     "no-warning-comments": [
       "error",
       {


### PR DESCRIPTION
This is because we find ternary structures to be particularly useful in JSX, and all of the alternative solutions are as ugly or worse.

Fixes #2