### PR TITLE
Disable eslint proptypes enforcement

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = {
       }
     ],
     "react/no-unused-prop-types": "off",
+    "react/prop-types": "off",
     "prettier/prettier": [
       "error",
       {


### PR DESCRIPTION
This is redundant now.  Flow will complain about missing type annotations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mathspace/eslint-config-mathspace/6)
<!-- Reviewable:end -->
