### PR TITLE
Add jsx-curly-brace-presence rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,11 @@ module.exports = {
     ],
     "react/no-unused-prop-types": "off",
     "react/prop-types": "off",
+    "react/jsx-curly-brace-presence": [
+      "error",
+      "never"
+    ],
+    "react/require-extension": "off",
     "prettier/prettier": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "eslint": ">= 3.6",
     "eslint-config-airbnb": ">= 11.1",
     "eslint-config-airbnb-base": ">= 7.1",
+    "eslint-config-prettier": ">= 2.3.0",
     "eslint-plugin-flowtype": ">= 2.25",
     "eslint-plugin-import": ">= 1.16",
     "eslint-plugin-jsx-a11y": ">= 2.2",
-    "eslint-plugin-react": ">= 6.2",
-    "prettier": ">= 1.5.2",
     "eslint-plugin-prettier": ">= 2.1.2",
-    "eslint-config-prettier": ">= 2.3.0"
+    "eslint-plugin-react": "7.7.0",
+    "prettier": ">= 1.5.2"
   }
 }


### PR DESCRIPTION
Force devs to avoid useless curly braces around strings in JSX (prop or children)

- Must update `eslint-plugin-react` to `7.7.0`
- Must set ` "react/require-extension": "off"` as it was deprecated since `eslint-plugin-react@7.0`
- NB: this is breaking

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mathspace/eslint-config-mathspace/9)
<!-- Reviewable:end -->
